### PR TITLE
Remove magic number

### DIFF
--- a/main.go
+++ b/main.go
@@ -16,10 +16,14 @@ import (
 	"github.com/pkg/errors"
 )
 
+const (
+	E_ERROR = 2
+)
+
 func main() {
 	if err := run(); err != nil {
 		fmt.Fprintf(os.Stderr, "%s", err)
-		os.Exit(2)
+		os.Exit(E_ERROR)
 	}
 }
 


### PR DESCRIPTION
Currently this tool throws `exit(2)` on error. This doesn't mean anything and is a magic number.

Instead this PR defines it as an error.

The choice of `2` is out of the scope of this PR.