### PR TITLE
fix case-insensitive import collision

### DIFF
--- a/main.go
+++ b/main.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/JackMordaunt/icns"
+	"github.com/jackmordaunt/icns"
 	"github.com/pkg/errors"
 )
 


### PR DESCRIPTION
This commit fixes the following error that might occur on case-insensitive systems:

```
case-insensitive import collision: "github.com/JackMordaunt/icns" and "github.com/jackmordaunt/icns"
```